### PR TITLE
Always capture whole lines

### DIFF
--- a/elysium.el
+++ b/elysium.el
@@ -203,6 +203,7 @@ Must be a number between 0 and 1, exclusive."
 
     (gptel--update-status " Waiting..." 'warning)
     (message "Querying %s..." (gptel-backend-name gptel-backend))
+    (deactivate-mark)
     (save-excursion
       (with-current-buffer chat-buffer
         (goto-char (point-max))


### PR DESCRIPTION
Thanks for this, it's a good extension on top of what gptel has already.

I'm very much only using this at the moment with regions, and when using regions i have had problems with it not creating a diff that matches my intent.  It's usually omiting a line from the response, but i think this is because the that is the region that is sent, doesn't match the lines that are recorded for the region.

For example, if my cursor is at the start of the line, none of that line is sent, but it is included in the offset calculation when applying the diffs to the buffer.

I think Elysium should try to only take entire lines from the region, because the diff is by line. 

There is a second small patch along with this, it deselects the current mark after sending the region, this is because otherwise the selection after applying the diff to the buffer doesn't match what was there before, so it's not really useful anymore.  There is an `insert-before-markers` that might help, but tbh, i don't think i want the selection afterwards, i want to be reviewing the returned code.


# Observed behavior
when running a query `add an argument to record the count`

## Initial state
![Screenshot 2024-11-28 at 08 07 33](https://github.com/user-attachments/assets/d4f50804-8214-4723-a68a-c6832e938bdc)

## After query state
![Screenshot 2024-11-28 at 08 09 14](https://github.com/user-attachments/assets/01e3b20f-2650-471e-81c7-a1ba5c01665a)

you can see in the screenshot that line 10 `count_to_hundred()` becomes part of the upper diff, and that is omitted from the lower diff.  This line is captured because my point is resting on the start of that line, but the contents of that line are not sent to the LLM.

# This branch's changes

start-pos
* this value will have the start of the line at the beginning of the region
* or the start of buffer.

end-pos, 
* if the region end is at the start of the line, move the point to the previous line, now move the point to the end of the current line and record the point the end of the buffer
* or the end of the buffer

These 2 pos positions should now hold the start/end of either the buffer or the lines in the region.  There is no way to select less than a line. 

## After query state
![Screenshot 2024-11-28 at 08 26 35](https://github.com/user-attachments/assets/0d695f57-70f8-464a-a074-2f1447c8f741)

