### PR TITLE
fix: Make sure the reasoning won't interfere with the way elysium parses the answer

### DIFF
--- a/elysium.el
+++ b/elysium.el
@@ -208,14 +208,15 @@ Must be a number between 0 and 1, exclusive."
       (with-current-buffer chat-buffer
         (goto-char (point-max))
         (when user-query
-	  (insert "\n\n")
+          (insert "\n\n")
           (insert (concat (gptel-prompt-prefix-string) user-query)))
         (insert "\n\n")))
 
-    (gptel-request full-query
-      :system elysium-base-prompt
-      :buffer chat-buffer
-      :callback (apply-partially #'elysium-handle-response code-buffer))))
+    (let ((gptel-include-reasoning nil))
+      (gptel-request full-query
+        :system elysium-base-prompt
+        :buffer chat-buffer
+        :callback (apply-partially #'elysium-handle-response code-buffer)))))
 
 (defun elysium-handle-response (code-buffer response info)
   "Handle the RESPONSE from gptel.


### PR DESCRIPTION
Using gemini, elysium gets an error like

```
error in process sentinel: Wrong type argument: stringp, (reasoning . "Okay, here's my interpretation of that request, formatted as requested:
```

I figured that elysium does not rely on reasoning anyway, so I simply asked nicely gptel to avoid using it for elysium queries.